### PR TITLE
Trap click started on mousedown rather than click.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   mix_test:

--- a/priv/static/phoenix_live_view.cjs.js
+++ b/priv/static/phoenix_live_view.cjs.js
@@ -3966,7 +3966,7 @@ var LiveSocket = class {
     }
   }
   bindClicks() {
-    window.addEventListener("click", (e) => this.clickStartedAtTarget = e.target);
+    window.addEventListener("mousedown", (e) => this.clickStartedAtTarget = e.target);
     this.bindClick("click", "click", false);
     this.bindClick("mousedown", "capture-click", true);
   }

--- a/priv/static/phoenix_live_view.esm.js
+++ b/priv/static/phoenix_live_view.esm.js
@@ -3953,7 +3953,7 @@ var LiveSocket = class {
     }
   }
   bindClicks() {
-    window.addEventListener("click", (e) => this.clickStartedAtTarget = e.target);
+    window.addEventListener("mousedown", (e) => this.clickStartedAtTarget = e.target);
     this.bindClick("click", "click", false);
     this.bindClick("mousedown", "capture-click", true);
   }

--- a/priv/static/phoenix_live_view.js
+++ b/priv/static/phoenix_live_view.js
@@ -3995,7 +3995,7 @@ within:
       }
     }
     bindClicks() {
-      window.addEventListener("click", (e) => this.clickStartedAtTarget = e.target);
+      window.addEventListener("mousedown", (e) => this.clickStartedAtTarget = e.target);
       this.bindClick("click", "click", false);
       this.bindClick("mousedown", "capture-click", true);
     }


### PR DESCRIPTION
The click event isn't raised until mouseup.

This fixes #1920 which was still broken as shown below

Reproduce issue:
![reproduce](https://user-images.githubusercontent.com/119121/227580624-e198ed37-ba6d-47b6-a73b-6f0823bb3e80.gif)

Fixed:
![fix](https://user-images.githubusercontent.com/119121/227580346-9b8f5871-2e44-4235-a812-c3ac93c640d0.gif)




